### PR TITLE
fix: prevent changeset release to trigger when nothing to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Create release pull request
         uses: changesets/action@v1
         with:
-          publish: npm run tag
+          # https://github.com/changesets/changesets/blob/main/docs/automating-changesets.md#blocking
+          publish: npx changeset status --since=master && npm run tag
         env:
           GITHUB_TOKEN: ${{ secrets.READ_AND_WRITE_TOKEN }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behaviour?

You can also link to an open issue here.

## What is the new behaviour?

...

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
