### PR TITLE
fix(ci): optionally tag on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "build": "rimraf ./dist && tsc -p tsconfig.build.json",
     "test": "vitest --config ./vitest.config.mts --dir ./src",
-    "tag": "git tag v$(node -p \"require('./package.json').version\")",
-    "posttag": "git push --tags",
+    "tag": "node ./scripts/tag.js",
     "preversion": "npm run prepare",
     "version": "git add package.json",
     "postversion": "git push && git push --tags",

--- a/scripts/tag.js
+++ b/scripts/tag.js
@@ -1,0 +1,19 @@
+const util = require('node:util');
+const exec = util.promisify(require('node:child_process').exec);
+const { version } = require('../package.json');
+
+async function tag() {
+  const currentVersion = `v${version}`;
+  await exec('git fetch --all --tags');
+  const gitTagResponse = await exec('git tag');
+  const existingTags = gitTagResponse.stdout.split('\n');
+
+  if (existingTags.includes(currentVersion)) {
+    console.log(`Tag ${currentVersion} already exists`);
+    return;
+  }
+
+  await exec(`git tag v${version}`);
+  await exec('git push --tags');
+}
+tag();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`changesets` fails on PR merge when no changesets files are present.

## What is the new behaviour?

Create new git tag only when it doesn't exist.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Relevant [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) has been added
